### PR TITLE
data feeding working code

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@ Adafruit_MPU6050 mpu;
 
 // Timing variables for precise sampling
 unsigned long lastSampleTime = 0;
-// const unsigned long SAMPLE_INTERVAL_US = 10000; // 100Hz sampling (10ms = 10,000 microseconds)
+const unsigned long SAMPLE_INTERVAL_US = 10000; // 100Hz sampling (10ms = 10,000 microseconds)
 
 // Calibration variables
 float accel_offset_x = 0.0, accel_offset_y = 0.0, accel_offset_z = 0.0;
@@ -21,8 +21,8 @@ void calibrateSensor() {
   
   // Collect calibration samples
   for (int i = 0; i < CALIBRATION_SAMPLES; i++) {
-    sensors_event_t accel;
-    mpu.getEvent(&accel, nullptr, nullptr);
+    sensors_event_t accel, gyro, temp;
+    mpu.getEvent(&accel, &gyro, &temp);
 
     accel_sum_x += accel.acceleration.x;
     accel_sum_y += accel.acceleration.y;
@@ -49,8 +49,7 @@ void collectSample() {
   sensors_event_t accel, gyro, temp;
   
   // Get sensor readings
-  mpu.getEvent(&accel, nullptr, nullptr);
-  // mpu.getEvent(&accel, &gyro, &temp);
+  mpu.getEvent(&accel, &gyro, &temp);
   
   // Apply calibration offsets
   float ax = accel.acceleration.x - accel_offset_x;
@@ -66,8 +65,8 @@ void collectSample() {
   Serial.print(",");
   Serial.print(ay, 4);
   Serial.print(",");
-  Serial.print(az, 4);
-  Serial.print(",");
+  Serial.println(az, 4);
+  // Serial.print(",");
   // Serial.print(gx, 4);
   // Serial.print(",");
   // Serial.print(gy, 4);
@@ -114,13 +113,13 @@ void setup() {
 }
 
 void loop() {
-  // unsigned long currentTime = micros();
+  unsigned long currentTime = micros();
   
   // Check if it's time for the next sample
-  // if (currentTime - lastSampleTime >= SAMPLE_INTERVAL_US) {
+  if (currentTime - lastSampleTime >= SAMPLE_INTERVAL_US) {
     collectSample();
-  //   lastSampleTime = currentTime;
-  // }
+    lastSampleTime = currentTime;
+  }
   
   // Small delay to prevent watchdog timeout
   delayMicroseconds(100);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,29 +8,29 @@ Adafruit_MPU6050 mpu;
 
 // Timing variables for precise sampling
 unsigned long lastSampleTime = 0;
-const unsigned long SAMPLE_INTERVAL_US = 10000; // 100Hz sampling (10ms = 10,000 microseconds)
+// const unsigned long SAMPLE_INTERVAL_US = 10000; // 100Hz sampling (10ms = 10,000 microseconds)
 
 // Calibration variables
 float accel_offset_x = 0.0, accel_offset_y = 0.0, accel_offset_z = 0.0;
-float gyro_offset_x = 0.0, gyro_offset_y = 0.0, gyro_offset_z = 0.0;
+// float gyro_offset_x = 0.0, gyro_offset_y = 0.0, gyro_offset_z = 0.0;
 const int CALIBRATION_SAMPLES = 1000;
 
 void calibrateSensor() {
   float accel_sum_x = 0, accel_sum_y = 0, accel_sum_z = 0;
-  float gyro_sum_x = 0, gyro_sum_y = 0, gyro_sum_z = 0;
+  // float gyro_sum_x = 0, gyro_sum_y = 0, gyro_sum_z = 0;
   
   // Collect calibration samples
   for (int i = 0; i < CALIBRATION_SAMPLES; i++) {
-    sensors_event_t accel, gyro, temp;
-    mpu.getEvent(&accel, &gyro, &temp);
-    
+    sensors_event_t accel;
+    mpu.getEvent(&accel, nullptr, nullptr);
+
     accel_sum_x += accel.acceleration.x;
     accel_sum_y += accel.acceleration.y;
     accel_sum_z += accel.acceleration.z;
     
-    gyro_sum_x += gyro.gyro.x;
-    gyro_sum_y += gyro.gyro.y;
-    gyro_sum_z += gyro.gyro.z;
+    // gyro_sum_x += gyro.gyro.x;
+    // gyro_sum_y += gyro.gyro.y;
+    // gyro_sum_z += gyro.gyro.z;
     
     delay(5); // 5ms delay between calibration samples
   }
@@ -40,25 +40,26 @@ void calibrateSensor() {
   accel_offset_y = accel_sum_y / CALIBRATION_SAMPLES;
   accel_offset_z = (accel_sum_z / CALIBRATION_SAMPLES) - 9.81; // Remove gravity from Z-axis
   
-  gyro_offset_x = gyro_sum_x / CALIBRATION_SAMPLES;
-  gyro_offset_y = gyro_sum_y / CALIBRATION_SAMPLES;
-  gyro_offset_z = gyro_sum_z / CALIBRATION_SAMPLES;
+  // gyro_offset_x = gyro_sum_x / CALIBRATION_SAMPLES;
+  // gyro_offset_y = gyro_sum_y / CALIBRATION_SAMPLES;
+  // gyro_offset_z = gyro_sum_z / CALIBRATION_SAMPLES;
 }
 
 void collectSample() {
   sensors_event_t accel, gyro, temp;
   
   // Get sensor readings
-  mpu.getEvent(&accel, &gyro, &temp);
+  mpu.getEvent(&accel, nullptr, nullptr);
+  // mpu.getEvent(&accel, &gyro, &temp);
   
   // Apply calibration offsets
   float ax = accel.acceleration.x - accel_offset_x;
   float ay = accel.acceleration.y - accel_offset_y;
   float az = accel.acceleration.z - accel_offset_z;
   
-  float gx = gyro.gyro.x - gyro_offset_x;
-  float gy = gyro.gyro.y - gyro_offset_y;
-  float gz = gyro.gyro.z - gyro_offset_z;
+  // float gx = gyro.gyro.x - gyro_offset_x;
+  // float gy = gyro.gyro.y - gyro_offset_y;
+  // float gz = gyro.gyro.z - gyro_offset_z;
   
   // Output data in Edge Impulse CSV format (comma-separated)
   Serial.print(ax, 4);
@@ -67,11 +68,11 @@ void collectSample() {
   Serial.print(",");
   Serial.print(az, 4);
   Serial.print(",");
-  Serial.print(gx, 4);
-  Serial.print(",");
-  Serial.print(gy, 4);
-  Serial.print(",");
-  Serial.println(gz, 4);
+  // Serial.print(gx, 4);
+  // Serial.print(",");
+  // Serial.print(gy, 4);
+  // Serial.print(",");
+  // Serial.println(gz, 4);
 }
 
 void setup() {
@@ -81,7 +82,7 @@ void setup() {
   }
   
   // Initialize I2C with optimized settings for ESP32 S3
-  Wire.begin(); // SDA=11, SCL=12 for ESP32 S3 Nano
+  Wire.begin(); // SDA=11, SCL=12 for ESP32 S3 Nano, No need to specify in begin() as it access the default pins
   Wire.setClock(400000); // 400kHz I2C clock for faster communication
   
   // Initialize MPU6050
@@ -96,7 +97,7 @@ void setup() {
   mpu.setAccelerometerRange(MPU6050_RANGE_4_G);
   
   // Gyroscope: ±500°/s range (suitable for hand movements)
-  mpu.setGyroRange(MPU6050_RANGE_500_DEG);
+  // mpu.setGyroRange(MPU6050_RANGE_500_DEG);
   
   // Digital Low Pass Filter: 94Hz bandwidth for vibration frequencies
   // This allows detection of tremor frequencies (4-12 Hz) while filtering noise
@@ -108,11 +109,12 @@ void setup() {
   
   // Start data collection automatically
   lastSampleTime = micros();
-  Serial.println("ax,ay,az,gx,gy,gz"); // CSV header for Edge Impulse
+  Serial.println("ax,ay,az"); // CSV header for Edge Impulse
+  // Serial.println("ax,ay,az,gx,gy,gz"); // CSV header for Edge Impulse
 }
 
 void loop() {
-  unsigned long currentTime = micros();
+  // unsigned long currentTime = micros();
   
   // Check if it's time for the next sample
   // if (currentTime - lastSampleTime >= SAMPLE_INTERVAL_US) {


### PR DESCRIPTION
This pull request updates the sensor data collection code to temporarily disable gyroscope data handling. The changes comment out all code related to gyroscope calibration, reading, and output, focusing the data collection exclusively on accelerometer data. Additionally, there are minor clarifications in comments related to I2C initialization.

**Sensor data handling:**

* All gyroscope offset variables, calibration, and reading code in `calibrateSensor()` and `collectSample()` are commented out, so only accelerometer data is processed and output. [[1]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L15-R20) [[2]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L31-R33) [[3]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L43-R45) [[4]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L59-R74)
* The CSV output header and data now include only accelerometer axes (`ax, ay, az`), with gyroscope fields commented out.

**Sensor setup:**

* The gyroscope range setting (`mpu.setGyroRange`) is commented out, so the default gyroscope configuration is used.

**Code clarity:**

* The comment for `Wire.begin()` is updated to clarify that specifying SDA/SCL pins is unnecessary for the ESP32 S3 Nano, as defaults are used.
* The sampling interval logic in the main loop is re-enabled to ensure samples are collected at the intended rate.